### PR TITLE
remove stray print statement

### DIFF
--- a/R/fitdist.R
+++ b/R/fitdist.R
@@ -71,7 +71,6 @@ fitdist <- function (data, distr, method = c("mle", "mme", "qme", "mge", "mse"),
     # manage starting/fixed values: may raise errors or return two named list
     arg_startfix <- manageparam(start.arg=start, fix.arg=fix.arg, obs=data, 
                                  distname=distname)
-    print(arg_startfix)
     
     #check inconsistent parameters
     argddistname <- names(formals(ddistname))


### PR DESCRIPTION
Dear All,

I noticed a stray print statement in `R/fitdist.R`, that filled up my logs. I removed it in this PR.

Alternatively, one could add a verbose flag to the input.

thanks for the great package!