### PR TITLE
Add flag to only show plots

### DIFF
--- a/R/descdist.R
+++ b/R/descdist.R
@@ -23,7 +23,7 @@
 ### 
 
 descdist <- function(data, discrete = FALSE, boot = NULL, method = "unbiased", graph = TRUE,
-obs.col = "darkblue", obs.pch = 16, boot.col = "orange")
+obs.col = "darkblue", obs.pch = 16, boot.col = "orange", plots.only = FALSE)
 {
     #if(is.mcnode(data)) data <- as.vector(data)
     if (missing(data) || !is.vector(data,mode="numeric"))
@@ -207,7 +207,7 @@ obs.col = "darkblue", obs.pch = 16, boot.col = "orange")
     } # end of is (graph)
     
     
-    return(structure(res, class = "descdist"))
+    if (!plots.only) {return(structure(res, class = "descdist"))}
     
 }
 


### PR DESCRIPTION
This might be kind of dumb and there's probably already a way to this that I've missed, but for my use case it'd be nice if I could just see the Cullen and Frey graph and not the summary statistics, so this adds a flag to do that.